### PR TITLE
ci: ai issue triage + consolidated pr labeler & stale bot

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,7 +22,8 @@
 
 "A: Datagen":
   - changed-files:
-      - any-glob-to-any-file: 'src/main/java/dev/amble/lib/datagen/**/*.java'
+      - any-glob-to-any-file:
+          - 'src/main/java/dev/amble/lib/datagen/**/*.java'
 
 "A: Core Tech":
   - changed-files:
@@ -44,7 +45,8 @@
 
 "A: Docs":
   - changed-files:
-      - any-glob-to-any-file: '**/*.md'
+      - any-glob-to-any-file:
+          - '**/*.md'
 
 "C: Render":
   - changed-files:
@@ -54,13 +56,16 @@
 
 "C: Textures":
   - changed-files:
-      - any-glob-to-any-file: 'src/main/resources/assets/*/textures/**/*.png'
+      - any-glob-to-any-file:
+          - 'src/main/resources/assets/*/textures/**/*.png'
 
 "C: Translations":
   - changed-files:
-      - any-glob-to-any-file: 'src/main/resources/assets/*/lang/**/*.json'
+      - any-glob-to-any-file:
+          - 'src/main/resources/assets/*/lang/**/*.json'
 
 "C: No Java":
   - changed-files:
       # if NONE of the changed files are java, it's a no-java change
-      - all-globs-to-all-files: '!src/main/java/**/*.java'
+      - all-globs-to-all-files:
+          - '!src/main/java/**/*.java'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -66,6 +66,9 @@
 
 "C: No Java":
   - changed-files:
-      # if NONE of the changed files are java, it's a no-java change
+      # applies when every changed file is non-java: '**' matches all files,
+      # then the negative glob requires none of them to be java. a negative-only
+      # rule never matches in actions/labeler, hence the '**' catch-all.
       - all-globs-to-all-files:
+          - '**'
           - '!src/main/java/**/*.java'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,66 @@
+# Path-based PR labels. Used by .github/workflows/pr-labeler.yml (actions/labeler).
+# Mirrors the AmbleKit label taxonomy (see .github for the full set).
+
+"A: Registry":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/main/java/dev/amble/lib/register/**/*.java'
+          - 'src/main/java/dev/amble/lib/container/**/*.java'
+
+"A: Datapacks":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/main/java/dev/amble/lib/register/datapack/**/*.java'
+          - 'src/main/resources/data/**'
+
+"A: Models":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/main/java/dev/amble/lib/animation/**/*.java'
+          - 'src/main/java/dev/amble/lib/client/bedrock/**/*.java'
+          - 'src/main/java/dev/amble/lib/client/model/**/*.java'
+
+"A: Datagen":
+  - changed-files:
+      - any-glob-to-any-file: 'src/main/java/dev/amble/lib/datagen/**/*.java'
+
+"A: Core Tech":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/main/java/dev/amble/lib/api/**/*.java'
+          - 'src/main/java/dev/amble/lib/mixin/**/*.java'
+          - 'src/main/java/dev/amble/lib/util/**/*.java'
+
+"A: Build":
+  - changed-files:
+      - any-glob-to-any-file:
+          - '*.gradle'
+          - 'gradle/**'
+          - 'gradle.properties'
+          - 'jitpack.yml'
+          - 'flake.nix'
+          - 'flake.lock'
+          - '.github/**'
+
+"A: Docs":
+  - changed-files:
+      - any-glob-to-any-file: '**/*.md'
+
+"C: Render":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/main/java/dev/amble/lib/**/client/**/*.java'
+          - 'src/main/java/dev/amble/lib/mixin/client/**/*.java'
+
+"C: Textures":
+  - changed-files:
+      - any-glob-to-any-file: 'src/main/resources/assets/*/textures/**/*.png'
+
+"C: Translations":
+  - changed-files:
+      - any-glob-to-any-file: 'src/main/resources/assets/*/lang/**/*.json'
+
+"C: No Java":
+  - changed-files:
+      # if NONE of the changed files are java, it's a no-java change
+      - all-globs-to-all-files: '!src/main/java/**/*.java'

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -157,8 +157,15 @@ jobs:
             D1) LABELS+=("D1: High");;
             D0) LABELS+=("D0: Very High");;
           esac
+          # allowlist the model's area/change labels to the documented taxonomy so a
+          # stray (but repo-existing) label can't sneak in if the model goes off-schema.
+          declare -A ALLOWED_AC=(
+            ["A: Registry"]=1 ["A: Datapacks"]=1 ["A: Models"]=1 ["A: Datagen"]=1
+            ["A: Core Tech"]=1 ["A: Build"]=1 ["A: Docs"]=1
+            ["C: Render"]=1 ["C: Textures"]=1 ["C: Translations"]=1 ["C: No Java"]=1
+          )
           while IFS= read -r l; do
-            [ -n "$l" ] && LABELS+=("$l")
+            [ -n "$l" ] && [ -n "${ALLOWED_AC[$l]:-}" ] && LABELS+=("$l")
           done < <(echo "$JSON" | jq -r '((.areas // []) + (.changes // []))[]')
           [ "$NEEDS" = "true" ] && LABELS+=("Issue: Awaiting Response")
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -97,13 +97,24 @@ jobs:
           REPO: ${{ github.repository }}
           NUM: ${{ steps.ctx.outputs.num }}
           RESP: ${{ steps.ai.outputs.response }}
+          # optional overrides - set as repo/org Actions variables instead of editing
+          # this file. find the ids via: gh api orgs/<org>/issue-fields
+          PRIORITY_FIELD_ID: ${{ vars.PRIORITY_FIELD_ID }}
+          EFFORT_FIELD_ID: ${{ vars.EFFORT_FIELD_ID }}
         run: |
           set -uo pipefail
 
-          JSON=$(printf '%s' "$RESP" | tr -d '\n' | grep -o '{.*}' | head -1 || true)
+          # prefer the whole response if it already parses as json (expected case:
+          # the model is asked for one line of minified json). otherwise strip any
+          # code fences and fall back to the first {...} block.
+          if printf '%s' "$RESP" | jq -e . >/dev/null 2>&1; then
+            JSON="$RESP"
+          else
+            JSON=$(printf '%s' "$RESP" | tr -d '\r\n' | sed 's/```json//g; s/```//g' | grep -o '{.*}' | head -1 || true)
+          fi
           echo "model json: $JSON"
 
-          if [ -z "$JSON" ] || ! echo "$JSON" | jq -e . >/dev/null 2>&1; then
+          if [ -z "$JSON" ] || ! printf '%s' "$JSON" | jq -e . >/dev/null 2>&1; then
             echo "no valid json -> S: Untriaged"
             gh issue edit "$NUM" --repo "$REPO" --add-label "S: Untriaged" || true
             exit 0
@@ -139,8 +150,8 @@ jobs:
           done < <(echo "$JSON" | jq -r '((.areas // []) + (.changes // []))[]')
           [ "$NEEDS" = "true" ] && LABELS+=("Issue: Awaiting Response")
 
-          # only apply labels that actually exist in the repo
-          mapfile -t EXISTING < <(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name')
+          # only apply labels that actually exist in the repo (page through all of them)
+          mapfile -t EXISTING < <(gh api "repos/$REPO/labels" --paginate --jq '.[].name')
           ADD=()
           for l in "${LABELS[@]:-}"; do
             for e in "${EXISTING[@]}"; do
@@ -165,8 +176,10 @@ jobs:
               | gh api --method POST "repositories/$RID/issues/$NUM/issue-field-values" --input - >/dev/null 2>&1 \
               || echo "field $1 not set"
           }
-          set_field 30052706 "$PRIORITY"   # Priority
-          set_field 30052709 "$EFFORT"     # Effort
+          # ids default to this org's Priority/Effort fields; override via the
+          # PRIORITY_FIELD_ID / EFFORT_FIELD_ID Actions variables if they differ.
+          set_field "${PRIORITY_FIELD_ID:-30052706}" "$PRIORITY"
+          set_field "${EFFORT_FIELD_ID:-30052709}" "$EFFORT"
 
           # triage comment
           {

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,7 +21,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: triage-${{ github.event.issue.number || github.event.inputs.issue }}
+  # key off trusted contexts only - issue number for issue events, run_id for
+  # manual runs (the dispatch input is user-controlled, don't put it in the key)
+  group: triage-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,7 +32,13 @@ jobs:
         id: ctx
         env:
           NUM: ${{ github.event.issue.number || github.event.inputs.issue }}
-        run: echo "num=$NUM" >> "$GITHUB_OUTPUT"
+        run: |
+          # NUM can come from a user-controlled workflow_dispatch input - require
+          # digits only so it can't inject newlines into $GITHUB_OUTPUT.
+          if ! printf '%s' "$NUM" | grep -qE '^[0-9]+$'; then
+            echo "invalid issue number: $NUM" >&2; exit 1
+          fi
+          echo "num=$NUM" >> "$GITHUB_OUTPUT"
 
       - name: Fetch issue (for manual runs) + build prompt
         env:
@@ -120,6 +126,10 @@ jobs:
             exit 0
           fi
 
+          # a previous run may have left S: Untriaged - clear it now that we have a
+          # valid classification so the issue isn't both triaged and untriaged.
+          gh issue edit "$NUM" --repo "$REPO" --remove-label "S: Untriaged" >/dev/null 2>&1 || true
+
           TYPE=$(echo "$JSON" | jq -r '.type // empty')
           PRIORITY=$(echo "$JSON" | jq -r '.priority // empty')
           EFFORT=$(echo "$JSON" | jq -r '.effort // empty')
@@ -152,13 +162,14 @@ jobs:
           done < <(echo "$JSON" | jq -r '((.areas // []) + (.changes // []))[]')
           [ "$NEEDS" = "true" ] && LABELS+=("Issue: Awaiting Response")
 
-          # only apply labels that actually exist in the repo (page through all of them)
-          mapfile -t EXISTING < <(gh api "repos/$REPO/labels" --paginate --jq '.[].name')
+          # only apply labels that actually exist in the repo - page through all of
+          # them into a set for O(1) membership instead of a nested scan.
+          declare -A HAVE
+          while IFS= read -r e; do [ -n "$e" ] && HAVE["$e"]=1; done \
+            < <(gh api "repos/$REPO/labels" --paginate --jq '.[].name')
           ADD=()
           for l in "${LABELS[@]:-}"; do
-            for e in "${EXISTING[@]}"; do
-              if [ "$l" = "$e" ]; then ADD+=("--add-label" "$l"); break; fi
-            done
+            [ -n "${HAVE[$l]:-}" ] && ADD+=("--add-label" "$l")
           done
           if [ "${#ADD[@]}" -gt 0 ]; then
             gh issue edit "$NUM" --repo "$REPO" "${ADD[@]}" || true
@@ -174,7 +185,9 @@ jobs:
           RID=$(gh api "repos/$REPO" --jq '.id')
           set_field() {
             [ -z "$2" ] && return 0
-            printf '{"issue_field_values":[{"field_id":%s,"value":"%s"}]}' "$1" "$2" \
+            # build the payload with jq so the value is properly json-escaped
+            jq -n --argjson fid "$1" --arg val "$2" \
+              '{issue_field_values:[{field_id:$fid,value:$val}]}' \
               | gh api --method POST "repositories/$RID/issues/$NUM/issue-field-values" --input - >/dev/null 2>&1 \
               || echo "field $1 not set"
           }

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,185 @@
+name: "Triage: AI"
+
+# AI-assisted issue triage using GitHub Models (actions/ai-inference).
+# On a new issue it asks a model to classify the issue against the AmbleKit
+# label taxonomy, then applies labels, sets the issue type, sets the org
+# Priority/Effort fields (best effort), and leaves a short triage comment.
+# If the model output can't be parsed it falls back to "S: Untriaged".
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Issue number to (re)triage"
+        required: true
+
+permissions:
+  issues: write
+  models: read
+  contents: read
+
+concurrency:
+  group: triage-${{ github.event.issue.number || github.event.inputs.issue }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve issue number
+        id: ctx
+        env:
+          NUM: ${{ github.event.issue.number || github.event.inputs.issue }}
+        run: echo "num=$NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch issue (for manual runs) + build prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.ctx.outputs.num }}
+          EVENT_TITLE: ${{ github.event.issue.title }}
+          EVENT_BODY: ${{ github.event.issue.body }}
+        run: |
+          set -euo pipefail
+          if [ -n "${EVENT_TITLE:-}" ]; then
+            TITLE="$EVENT_TITLE"; BODY="$EVENT_BODY"
+          else
+            TITLE=$(gh issue view "$NUM" --repo "$REPO" --json title --jq '.title')
+            BODY=$(gh issue view "$NUM" --repo "$REPO" --json body --jq '.body')
+          fi
+          {
+            echo "Issue #$NUM"
+            echo "Title: $TITLE"
+            echo
+            echo "Body:"
+            echo "${BODY:-(no body)}"
+          } > "$RUNNER_TEMP/triage-prompt.txt"
+
+      - name: AI classify
+        id: ai
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o-mini
+          max-completion-tokens: 500
+          prompt-file: ${{ runner.temp }}/triage-prompt.txt
+          system-prompt: |
+            You triage GitHub issues for AmbleKit (a.k.a. modkit) - a Fabric 1.20.1
+            Minecraft *library* mod (Java). It provides: a reflection-based registry
+            container API, a GSON datapack registry (SimpleDatapackRegistry), datagen
+            (auto models/lang/tags from annotations), and a "bedrock" block-entity
+            model + animation system.
+
+            Classify the issue and reply with ONE LINE of minified JSON, no code
+            fences, no prose. Schema (use EXACTLY these allowed values):
+
+            {
+              "type": "Bug" | "Feature" | "Task",
+              "priority": "Urgent" | "High" | "Medium" | "Low",
+              "effort": "High" | "Medium" | "Low",
+              "difficulty": "DB" | "D3" | "D2" | "D1" | "D0",
+              "areas": [ subset of: "A: Registry","A: Datapacks","A: Models","A: Datagen","A: Core Tech","A: Build","A: Docs" ],
+              "changes": [ subset of: "C: Render","C: Textures","C: Translations","C: No Java" ],
+              "summary": "one short lowercase sentence",
+              "needs_info": true | false
+            }
+
+            Guidance: crashes / data loss -> priority High or Urgent. A vague report
+            with no repro/logs -> needs_info=true. "Task" = docs/chores/proposals,
+            "Feature" = new API/content, "Bug" = something broken. difficulty is how
+            much codebase knowledge a fix needs (DB beginner .. D0 extreme). Pick the
+            1-2 most relevant areas; do not invent labels outside the lists.
+
+      - name: Apply triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUM: ${{ steps.ctx.outputs.num }}
+          RESP: ${{ steps.ai.outputs.response }}
+        run: |
+          set -uo pipefail
+
+          JSON=$(printf '%s' "$RESP" | tr -d '\n' | grep -o '{.*}' | head -1 || true)
+          echo "model json: $JSON"
+
+          if [ -z "$JSON" ] || ! echo "$JSON" | jq -e . >/dev/null 2>&1; then
+            echo "no valid json -> S: Untriaged"
+            gh issue edit "$NUM" --repo "$REPO" --add-label "S: Untriaged" || true
+            exit 0
+          fi
+
+          TYPE=$(echo "$JSON" | jq -r '.type // empty')
+          PRIORITY=$(echo "$JSON" | jq -r '.priority // empty')
+          EFFORT=$(echo "$JSON" | jq -r '.effort // empty')
+          DIFF=$(echo "$JSON" | jq -r '.difficulty // empty')
+          SUMMARY=$(echo "$JSON" | jq -r '.summary // empty')
+          NEEDS=$(echo "$JSON" | jq -r '.needs_info // false')
+
+          LABELS=()
+          case "$TYPE" in
+            Bug) LABELS+=("T: Bugfix");;
+            Feature) LABELS+=("T: New Feature");;
+          esac
+          case "$PRIORITY" in
+            Urgent) LABELS+=("P0: Critical");;
+            High) LABELS+=("P1: High");;
+            Medium) LABELS+=("P2: Raised");;
+            Low) LABELS+=("P3: Standard");;
+          esac
+          case "$DIFF" in
+            DB) LABELS+=("DB: Beginner Friendly");;
+            D3) LABELS+=("D3: Low");;
+            D2) LABELS+=("D2: Medium");;
+            D1) LABELS+=("D1: High");;
+            D0) LABELS+=("D0: Very High");;
+          esac
+          while IFS= read -r l; do
+            [ -n "$l" ] && LABELS+=("$l")
+          done < <(echo "$JSON" | jq -r '((.areas // []) + (.changes // []))[]')
+          [ "$NEEDS" = "true" ] && LABELS+=("Issue: Awaiting Response")
+
+          # only apply labels that actually exist in the repo
+          mapfile -t EXISTING < <(gh label list --repo "$REPO" --limit 200 --json name --jq '.[].name')
+          ADD=()
+          for l in "${LABELS[@]:-}"; do
+            for e in "${EXISTING[@]}"; do
+              if [ "$l" = "$e" ]; then ADD+=("--add-label" "$l"); break; fi
+            done
+          done
+          if [ "${#ADD[@]}" -gt 0 ]; then
+            gh issue edit "$NUM" --repo "$REPO" "${ADD[@]}" || true
+          fi
+
+          # GitHub issue type (best effort - org-level)
+          if [ -n "$TYPE" ]; then
+            gh api --method PATCH "repos/$REPO/issues/$NUM" -f type="$TYPE" >/dev/null 2>&1 \
+              || echo "issue type not set (token may lack org perms)"
+          fi
+
+          # org Priority/Effort issue fields (best effort)
+          RID=$(gh api "repos/$REPO" --jq '.id')
+          set_field() {
+            [ -z "$2" ] && return 0
+            printf '{"issue_field_values":[{"field_id":%s,"value":"%s"}]}' "$1" "$2" \
+              | gh api --method POST "repositories/$RID/issues/$NUM/issue-field-values" --input - >/dev/null 2>&1 \
+              || echo "field $1 not set"
+          }
+          set_field 30052706 "$PRIORITY"   # Priority
+          set_field 30052709 "$EFFORT"     # Effort
+
+          # triage comment
+          {
+            echo "🤖 **auto-triage** (github models)"
+            echo
+            echo "| type | priority | effort | difficulty |"
+            echo "|---|---|---|---|"
+            echo "| ${TYPE:-?} | ${PRIORITY:-?} | ${EFFORT:-?} | ${DIFF:-?} |"
+            echo
+            [ -n "$SUMMARY" ] && echo "> $SUMMARY"
+            echo
+            [ "$NEEDS" = "true" ] && echo "looks like its missing repro steps / logs - added \`Issue: Awaiting Response\`."
+            echo
+            echo "_labels are a best guess, a maintainer will confirm._"
+          } > "$RUNNER_TEMP/comment.md"
+          gh issue comment "$NUM" --repo "$REPO" --body-file "$RUNNER_TEMP/comment.md" || true

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: AI classify
         id: ai
-        uses: actions/ai-inference@v1
+        uses: actions/ai-inference@b81b2afb8390ee6839b494a404766bef6493c7d9 # v1
         with:
           model: openai/gpt-4o-mini
           max-completion-tokens: 500
@@ -131,6 +131,8 @@ jobs:
           case "$TYPE" in
             Bug) LABELS+=("T: Bugfix");;
             Feature) LABELS+=("T: New Feature");;
+            # Task has no T: label in the taxonomy - it's conveyed by the GitHub
+            # issue type set further down, so no label is added here on purpose.
           esac
           case "$PRIORITY" in
             Urgent) LABELS+=("P0: Critical");;

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/ai-inference@b81b2afb8390ee6839b494a404766bef6493c7d9 # v1
         with:
           model: openai/gpt-4o-mini
-          max-completion-tokens: 500
+          max-tokens: 500
           prompt-file: ${{ runner.temp }}/triage-prompt.txt
           system-prompt: |
             You triage GitHub issues for AmbleKit (a.k.a. modkit) - a Fabric 1.20.1
@@ -134,7 +134,7 @@ jobs:
           PRIORITY=$(echo "$JSON" | jq -r '.priority // empty')
           EFFORT=$(echo "$JSON" | jq -r '.effort // empty')
           DIFF=$(echo "$JSON" | jq -r '.difficulty // empty')
-          SUMMARY=$(echo "$JSON" | jq -r '.summary // empty')
+          SUMMARY=$(echo "$JSON" | jq -r '.summary // empty' | tr '\r\n' ' ' | cut -c1-200)
           NEEDS=$(echo "$JSON" | jq -r '.needs_info // false')
 
           LABELS=()

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,40 @@
+name: "Labels: PR"
+
+# Consolidated PR labeling: path-based area labels + size labels.
+# (AIT splits these across ~7 files; this does it in one.)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  paths:
+    name: Path labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true
+
+  size:
+    name: Size label
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "10": "S",
+              "100": "M",
+              "1000": "L",
+              "5000": "XL"
+            }

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -17,7 +17,7 @@ jobs:
     name: Path labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           sync-labels: true
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - uses: pascalgn/size-label-action@v0.5.5
+      - uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 30
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: "Triage: Stale"
+
+# Marks quiet issues/PRs as "S: Stale" and eventually closes them.
+# High-priority, frozen, and intentional items are exempt.
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: "S: Stale"
+          stale-pr-label: "S: Stale"
+          remove-stale-when-updated: true
+          stale-issue-message: >
+            this ones gone quiet - marking it `S: Stale`. give it a poke if its
+            still relevant, otherwise itll close in a week.
+          stale-pr-message: >
+            no activity on this for a while - marking it `S: Stale`. push something
+            or comment if its still alive, otherwise itll close in a week.
+          close-issue-message: "closing as stale - comment to reopen if needed."
+          close-pr-message: "closing as stale - reopen if you come back to it."
+          exempt-issue-labels: "P0: Critical,P1: High,S: Frozen,Issue: Intended Feature,S: Help Wanted"
+          exempt-pr-labels: "S: DO NOT MERGE,S: Frozen,P0: Critical,P1: High"
+          exempt-all-milestones: true
+          operations-per-run: 60


### PR DESCRIPTION
automated issue/PR triage, modelled on AIT's labeler suite but consolidated and AI-assisted.

### what's here

**`.github/workflows/issue-triage.yml` - AI triage (the new bit)**
on a new issue, GitHub Models (`actions/ai-inference`, free built-in LLM) classifies it against our label taxonomy and:
- applies the matching `T:` / `P:` / `D:` / `A:` / `C:` labels (only ones that actually exist in the repo)
- sets the GitHub **issue type** (Bug/Feature/Task) - best effort
- sets the org **Priority** + **Effort** fields - best effort
- leaves a short triage comment with its reasoning
- falls back to `S: Untriaged` if the model output can't be parsed
- also runnable manually via `workflow_dispatch` with an issue number

**`.github/workflows/pr-labeler.yml`** - path-based area labels (`actions/labeler` + `.github/labeler.yml`) + size labels (XS-XL), one file instead of AIT's seven.

**`.github/workflows/stale.yml`** - marks quiet issues/PRs `S: Stale` after 30d, closes after 7 more. Exempts `P0`/`P1`/`S: Frozen`/`Issue: Intended Feature`/`S: Help Wanted`.

**`.github/labeler.yml`** - path -> area/change label map for this repo's `dev.amble.lib` layout.

### before it fully works
- **merge to the default branch** - `issues:` and `schedule:` triggers only fire from the default branch.
- **GitHub Models** must be enabled for the org/repo (Settings -> Models). If not, only the labeler/size/stale jobs run.
- issue **type** + **Priority/Effort fields** are org-level; the default `GITHUB_TOKEN` may not have perms, hence best-effort (`|| true`). If you want them guaranteed, swap in a PAT/app token with org access as a secret and set `GH_TOKEN` to it in the triage job.
- no Copilot auto-assignment wired in (per the chosen scope) - easy to add later as an extra step if wanted.
