### PR TITLE
fix(datapack): clear client registry on disconnect

### DIFF
--- a/src/main/java/dev/amble/lib/register/datapack/SimpleDatapackRegistry.java
+++ b/src/main/java/dev/amble/lib/register/datapack/SimpleDatapackRegistry.java
@@ -63,8 +63,10 @@ public abstract class SimpleDatapackRegistry<T extends Identifiable> extends Dat
         if (!this.sync)
             return;
 
-        ClientPlayNetworking.registerGlobalReceiver(this.packet,
-                (client, handler, buf, responseSender) -> this.readFromServer(buf));
+        ClientPlayNetworking.registerGlobalReceiver(this.packet, (client, handler, buf, responseSender) -> {
+            PacketByteBuf copy = new PacketByteBuf(buf.copy());
+            client.execute(() -> this.readFromServer(copy));
+        });
 
         ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
             this.clearCache();

--- a/src/main/java/dev/amble/lib/register/datapack/SimpleDatapackRegistry.java
+++ b/src/main/java/dev/amble/lib/register/datapack/SimpleDatapackRegistry.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.util.function.Function;
 
 import com.mojang.serialization.Codec;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
@@ -64,6 +65,11 @@ public abstract class SimpleDatapackRegistry<T extends Identifiable> extends Dat
 
         ClientPlayNetworking.registerGlobalReceiver(this.packet,
                 (client, handler, buf, responseSender) -> this.readFromServer(buf));
+
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
+            this.clearCache();
+            this.defaults();
+        });
     }
 
     /**
@@ -109,7 +115,7 @@ public abstract class SimpleDatapackRegistry<T extends Identifiable> extends Dat
         if (!this.sync)
             return;
 
-        // this.clearCache();
+        this.clearCache();
         this.defaults();
         int size = buf.readInt();
 

--- a/src/main/java/dev/amble/lib/register/datapack/SimpleDatapackRegistry.java
+++ b/src/main/java/dev/amble/lib/register/datapack/SimpleDatapackRegistry.java
@@ -65,7 +65,17 @@ public abstract class SimpleDatapackRegistry<T extends Identifiable> extends Dat
 
         ClientPlayNetworking.registerGlobalReceiver(this.packet, (client, handler, buf, responseSender) -> {
             PacketByteBuf copy = new PacketByteBuf(buf.copy());
-            client.execute(() -> this.readFromServer(copy));
+            client.execute(() -> {
+                try {
+                    // skip if we've since disconnected/reconnected so stale server data
+                    // can't repopulate the registry after the fact
+                    if (client.getNetworkHandler() != handler)
+                        return;
+                    this.readFromServer(copy);
+                } finally {
+                    copy.release();
+                }
+            });
         });
 
         ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {


### PR DESCRIPTION
fixes #26

Server-synced datapack entries were leaking into the next world / singleplayer because the client registry was never cleared on disconnect and the cache clear in `readFromServer` was commented out. Clicking a leaked (server-only) entry in singleplayer crashed the game.

Changes in `SimpleDatapackRegistry`:
- Register `ClientPlayConnectionEvents.DISCONNECT` in `onClientInit()` to `clearCache()` then re-apply `defaults()`.
- Un-comment `this.clearCache()` at the start of `readFromServer` so server data replaces cleanly instead of merging with leaked state.

Verified with `./gradlew compileJava` (BUILD SUCCESSFUL).