### PR TITLE
fix(animation): respect lerp_mode for array-form keyframes

### DIFF
--- a/src/main/java/dev/amble/lib/client/bedrock/BedrockAnimationAdapter.java
+++ b/src/main/java/dev/amble/lib/client/bedrock/BedrockAnimationAdapter.java
@@ -199,8 +199,8 @@ public class BedrockAnimationAdapter implements JsonDeserializer<BedrockAnimatio
 					keyframes.put(time, new BedrockAnimation.JumpKeyFrame(time, transformation, type, deserializeSimpleBoneValue(kfObj.has("pre") ? kfObj.getAsJsonArray("pre") : post.getAsJsonArray(), transformation),
 							deserializeSimpleBoneValue(post.getAsJsonArray(), transformation)));
 				} else if (kfObj.has("pre")) {
-					JsonElement pre = kfObj.get("pre");
-					keyframes.put(time, new BedrockAnimation.JumpKeyFrame(time, transformation, type, deserializeSimpleBoneValue(pre.getAsJsonArray(), transformation), deserializeSimpleBoneValue(pre.getAsJsonArray(), transformation)));
+					BedrockAnimation.SimpleBoneValue pre = deserializeSimpleBoneValue(kfObj.getAsJsonArray("pre"), transformation);
+					keyframes.put(time, new BedrockAnimation.JumpKeyFrame(time, transformation, type, pre, pre));
 				}
 			} else {
 				keyframes.put(time, new BedrockAnimation.SimpleKeyFrame(

--- a/src/main/java/dev/amble/lib/client/bedrock/BedrockAnimationAdapter.java
+++ b/src/main/java/dev/amble/lib/client/bedrock/BedrockAnimationAdapter.java
@@ -184,14 +184,10 @@ public class BedrockAnimationAdapter implements JsonDeserializer<BedrockAnimatio
 		for (Map.Entry<String, JsonElement> entry : frames.entrySet()) {
 			double time = Double.parseDouble(entry.getKey());
 			JsonElement keyframeJson = entry.getValue();
+			BedrockAnimation.InterpolationType type = parseInterpolationType(keyframeJson);
 
 			if (keyframeJson.isJsonObject()) {
 				JsonObject kfObj = keyframeJson.getAsJsonObject();
-				BedrockAnimation.InterpolationType type = "catmullrom".equals(
-						kfObj.has("lerp_mode") ? kfObj.get("lerp_mode").getAsString() : "linear")
-						? BedrockAnimation.InterpolationType.SMOOTH
-						: BedrockAnimation.InterpolationType.LINEAR;
-
 
 				if (kfObj.has("post")) {
 					JsonElement post = kfObj.get("post");
@@ -199,19 +195,34 @@ public class BedrockAnimationAdapter implements JsonDeserializer<BedrockAnimatio
 							deserializeSimpleBoneValue(post.getAsJsonArray(), transformation)));
 				} else if (kfObj.has("pre")) {
 					JsonElement pre = kfObj.get("pre");
-					keyframes.put(time, new BedrockAnimation.JumpKeyFrame(time, transformation, type, deserializeSimpleBoneValue(pre.getAsJsonArray(), transformation), deserializeSimpleBoneValue(kfObj.has("post") ? kfObj.getAsJsonArray("post") : pre.getAsJsonArray(), transformation)));
+					keyframes.put(time, new BedrockAnimation.JumpKeyFrame(time, transformation, type, deserializeSimpleBoneValue(pre.getAsJsonArray(), transformation), deserializeSimpleBoneValue(pre.getAsJsonArray(), transformation)));
 				}
 			} else {
 				keyframes.put(time, new BedrockAnimation.SimpleKeyFrame(
 						time,
 						transformation,
-						BedrockAnimation.InterpolationType.LINEAR,
+						type,
 						deserializeSimpleBoneValue(keyframeJson.getAsJsonArray(), transformation)
 				));
 			}
 		}
 
 		return keyframes;
+	}
+
+	private BedrockAnimation.InterpolationType parseInterpolationType(JsonElement keyframeJson) {
+		String lerpMode = "linear";
+
+		if (keyframeJson.isJsonObject()) {
+			JsonObject kfObj = keyframeJson.getAsJsonObject();
+			if (kfObj.has("lerp_mode")) {
+				lerpMode = kfObj.get("lerp_mode").getAsString();
+			}
+		}
+
+		return "catmullrom".equals(lerpMode)
+				? BedrockAnimation.InterpolationType.SMOOTH
+				: BedrockAnimation.InterpolationType.LINEAR;
 	}
 
 	private BedrockAnimation.SimpleBoneValue deserializeSimpleBoneValue(JsonArray array, BedrockAnimation.Transformation transformation) {

--- a/src/main/java/dev/amble/lib/client/bedrock/BedrockAnimationAdapter.java
+++ b/src/main/java/dev/amble/lib/client/bedrock/BedrockAnimationAdapter.java
@@ -181,10 +181,15 @@ public class BedrockAnimationAdapter implements JsonDeserializer<BedrockAnimatio
 	private BedrockAnimation.KeyFrameBoneValue deserializeKeyframe(JsonObject frames, BedrockAnimation.Transformation transformation) {
 		BedrockAnimation.KeyFrameBoneValue keyframes = new BedrockAnimation.KeyFrameBoneValue();
 
+		// lerp_mode may be declared once at the track level; it becomes the default for every keyframe
+		BedrockAnimation.InterpolationType trackType = parseInterpolationType(frames);
+
 		for (Map.Entry<String, JsonElement> entry : frames.entrySet()) {
+			if ("lerp_mode".equals(entry.getKey())) continue;
+
 			double time = Double.parseDouble(entry.getKey());
 			JsonElement keyframeJson = entry.getValue();
-			BedrockAnimation.InterpolationType type = parseInterpolationType(keyframeJson);
+			BedrockAnimation.InterpolationType type = parseInterpolationType(keyframeJson, trackType);
 
 			if (keyframeJson.isJsonObject()) {
 				JsonObject kfObj = keyframeJson.getAsJsonObject();
@@ -210,19 +215,23 @@ public class BedrockAnimationAdapter implements JsonDeserializer<BedrockAnimatio
 		return keyframes;
 	}
 
-	private BedrockAnimation.InterpolationType parseInterpolationType(JsonElement keyframeJson) {
-		String lerpMode = "linear";
+	private BedrockAnimation.InterpolationType parseInterpolationType(JsonElement json) {
+		return parseInterpolationType(json, BedrockAnimation.InterpolationType.LINEAR);
+	}
 
-		if (keyframeJson.isJsonObject()) {
-			JsonObject kfObj = keyframeJson.getAsJsonObject();
-			if (kfObj.has("lerp_mode")) {
-				lerpMode = kfObj.get("lerp_mode").getAsString();
+	// Reads lerp_mode from a keyframe (object form) or track object, falling back to fallback when absent.
+	// Array-form keyframes carry no lerp_mode, so they inherit the fallback (typically the track-level default).
+	private BedrockAnimation.InterpolationType parseInterpolationType(JsonElement json, BedrockAnimation.InterpolationType fallback) {
+		if (json.isJsonObject()) {
+			JsonObject obj = json.getAsJsonObject();
+			if (obj.has("lerp_mode")) {
+				return "catmullrom".equals(obj.get("lerp_mode").getAsString())
+						? BedrockAnimation.InterpolationType.SMOOTH
+						: BedrockAnimation.InterpolationType.LINEAR;
 			}
 		}
 
-		return "catmullrom".equals(lerpMode)
-				? BedrockAnimation.InterpolationType.SMOOTH
-				: BedrockAnimation.InterpolationType.LINEAR;
+		return fallback;
 	}
 
 	private BedrockAnimation.SimpleBoneValue deserializeSimpleBoneValue(JsonArray array, BedrockAnimation.Transformation transformation) {


### PR DESCRIPTION
fixes #50

`BedrockAnimationAdapter.deserializeKeyframe` hardcoded `InterpolationType.LINEAR` for keyframes written as a plain JSON array, ignoring `lerp_mode`. This made `lerp_mode: "catmullrom"` keyframes render as hard linear segments instead of smooth.

- extract `parseInterpolationType` so every keyframe form (object and array) maps `catmullrom` -> SMOOTH, otherwise LINEAR
- apply the parsed type to the array-form `SimpleKeyFrame` branch instead of hardcoding LINEAR
- drop the dead `kfObj.has("post")` ternary in the `pre`-only branch (always false there)

Interpolation math in `BedrockAnimation.resolve` is unchanged; this is purely a parsing fix. Verified with `./gradlew build` (compile + tests green).