### PR TITLE
fix(animation): clear tracked animation when an animated block is removed

### DIFF
--- a/src/main/java/dev/amble/lib/blockentity/ABlockEntity.java
+++ b/src/main/java/dev/amble/lib/blockentity/ABlockEntity.java
@@ -1,5 +1,7 @@
 package dev.amble.lib.blockentity;
 
+import dev.amble.lib.animation.AnimatedInstance;
+import dev.amble.lib.animation.AnimationTracker;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
@@ -30,7 +32,13 @@ public abstract class ABlockEntity extends BlockEntity {
         return ActionResult.PASS;
     }
 
-    public void onBreak(BlockState state, World world, BlockPos pos, BlockState newState) { }
+    public void onBreak(BlockState state, World world, BlockPos pos, BlockState newState) {
+        // Clear any tracked animation so a new block placed at the same position
+        // does not inherit stale animation state (see issues #68 and #45).
+        // Only the server holds the authoritative tracker and performs the sync.
+        if (!world.isClient && this instanceof AnimatedInstance animated)
+            AnimationTracker.getInstance().remove(animated);
+    }
 
     protected void sync() {
         if (this.world != null && this.world.getChunkManager() instanceof ServerChunkManager chunkManager)

--- a/src/main/java/dev/amble/lib/blockentity/ABlockEntity.java
+++ b/src/main/java/dev/amble/lib/blockentity/ABlockEntity.java
@@ -1,7 +1,5 @@
 package dev.amble.lib.blockentity;
 
-import dev.amble.lib.animation.AnimatedInstance;
-import dev.amble.lib.animation.AnimationTracker;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
@@ -32,13 +30,7 @@ public abstract class ABlockEntity extends BlockEntity {
         return ActionResult.PASS;
     }
 
-    public void onBreak(BlockState state, World world, BlockPos pos, BlockState newState) {
-        // Clear any tracked animation so a new block placed at the same position
-        // does not inherit stale animation state (see issues #68 and #45).
-        // Only the server holds the authoritative tracker and performs the sync.
-        if (!world.isClient && this instanceof AnimatedInstance animated)
-            AnimationTracker.getInstance().remove(animated);
-    }
+    public void onBreak(BlockState state, World world, BlockPos pos, BlockState newState) { }
 
     protected void sync() {
         if (this.world != null && this.world.getChunkManager() instanceof ServerChunkManager chunkManager)

--- a/src/main/java/dev/amble/lib/mixin/BlockEntityMixin.java
+++ b/src/main/java/dev/amble/lib/mixin/BlockEntityMixin.java
@@ -32,7 +32,13 @@ public abstract class BlockEntityMixin {
 
         // Only the server holds the authoritative tracker and drives the client sync.
         World world = ((BlockEntity) (Object) this).getWorld();
-        if (world != null && !world.isClient)
-            AnimationTracker.getInstance().remove(animated);
+        if (world == null || world.isClient)
+            return;
+
+        // markRemoved fires constantly on chunk unload, so only sync a removal when
+        // this instance actually has a tracked animation - avoids pointless packets.
+        AnimationTracker tracker = AnimationTracker.getInstance();
+        if (tracker.get(animated) != null)
+            tracker.remove(animated);
     }
 }

--- a/src/main/java/dev/amble/lib/mixin/BlockEntityMixin.java
+++ b/src/main/java/dev/amble/lib/mixin/BlockEntityMixin.java
@@ -1,0 +1,38 @@
+package dev.amble.lib.mixin;
+
+import dev.amble.lib.animation.AnimatedInstance;
+import dev.amble.lib.animation.AnimationTracker;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Clears tracked animation state for any animated block entity when it is removed
+ * (broken or unloaded).
+ *
+ * <p>This hooks the vanilla {@link BlockEntity} rather than {@code ABlockEntity} on
+ * purpose: a block entity's animation UUID is derived from its world + position
+ * ({@code AnimatedBlockEntity#getUuid}), so a block placed where an animated one was
+ * broken would otherwise inherit the stale animation (#68), and an animation would
+ * survive chunk unload/reload (#45). Keying off {@link AnimatedInstance} means this
+ * also covers downstream block entities that implement {@code AnimatedBlockEntity}
+ * directly on a vanilla {@code BlockEntity} (e.g. addon cover/monitor blocks), not
+ * just {@code ABlockEntity} subclasses.
+ */
+@Mixin(BlockEntity.class)
+public abstract class BlockEntityMixin {
+
+    @Inject(method = "markRemoved", at = @At("HEAD"))
+    private void amblekit$clearAnimationOnRemove(CallbackInfo ci) {
+        if (!((Object) this instanceof AnimatedInstance animated))
+            return;
+
+        // Only the server holds the authoritative tracker and drives the client sync.
+        World world = ((BlockEntity) (Object) this).getWorld();
+        if (world != null && !world.isClient)
+            AnimationTracker.getInstance().remove(animated);
+    }
+}

--- a/src/main/resources/amblekit.mixins.json
+++ b/src/main/resources/amblekit.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "AbstractBlockAccessor",
+    "BlockEntityMixin",
     "BlockMixin",
     "EndermanEntityMixin",
     "ItemMixin",


### PR DESCRIPTION
Fixes #68 and #45.

Animated block entities derive their animation UUID from world + position (`AnimatedBlockEntity#getUuid`), and animation state was never cleared when a block was removed - so a block placed where an animated one was broken inherited the stale animation (#68), and animations survived chunk unload/reload (#45).

This clears tracked animation state for **any** `AnimatedInstance` block entity via a mixin on vanilla `BlockEntity#markRemoved` (server-side only). Hooking the vanilla lifecycle rather than `ABlockEntity.onBreak` means it also covers downstream block entities that implement `AnimatedBlockEntity` on a plain `BlockEntity` (e.g. ait-extras' `MonitorCoverBlockEntity`), and because `markRemoved` fires on chunk unload it fixes #45 too. Only syncs a removal when an animation is actually tracked, to avoid needless packets on unload.
