### PR TITLE
fix(registry): skip already-registered fields to avoid double registration

### DIFF
--- a/src/main/java/dev/amble/lib/container/RegistryContainer.java
+++ b/src/main/java/dev/amble/lib/container/RegistryContainer.java
@@ -55,6 +55,13 @@ public interface RegistryContainer<T> {
 
                 Identifier id = new Identifier(namespace, name);
 
+                // Skip values that are already present in the target registry.
+                // Some external APIs (e.g. TerraformersMC's boat API) register the
+                // value themselves, so re-registering the same instance here would
+                // throw "Attempted to register object ... twice". See issue #56.
+                if (container.getRegistry().getKey(v).isPresent())
+                    continue;
+
                 Registry.register(container.getRegistry(), id, v);
                 container.postProcessField(id, v, field);
             }

--- a/src/main/java/dev/amble/lib/container/RegistryContainer.java
+++ b/src/main/java/dev/amble/lib/container/RegistryContainer.java
@@ -3,8 +3,10 @@ package dev.amble.lib.container;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Locale;
+import java.util.Optional;
 
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
 
 import dev.amble.lib.AmbleKit;
@@ -55,14 +57,20 @@ public interface RegistryContainer<T> {
 
                 Identifier id = new Identifier(namespace, name);
 
-                // Skip values that are already present in the target registry.
-                // Some external APIs (e.g. TerraformersMC's boat API) register the
-                // value themselves, so re-registering the same instance here would
-                // throw "Attempted to register object ... twice". See issue #56.
-                if (container.getRegistry().getKey(v).isPresent())
-                    continue;
+                // Only register the value when it isn't already present in the target
+                // registry. Some external APIs (e.g. TerraformersMC's boat API) register
+                // the value themselves, so re-registering the same instance would throw
+                // "Attempted to register object ... twice". See issue #56. When that
+                // happens we still run postProcessField (block items, renderers, ...)
+                // using the registry's existing identifier.
+                Optional<RegistryKey<T>> existing = container.getRegistry().getKey(v);
 
-                Registry.register(container.getRegistry(), id, v);
+                if (existing.isPresent()) {
+                    id = existing.get().getValue();
+                } else {
+                    Registry.register(container.getRegistry(), id, v);
+                }
+
                 container.postProcessField(id, v, field);
             }
 


### PR DESCRIPTION
fixes #56

The reflection-based `RegistryContainer.register` scanner called `Registry.register(...)` for every matching static field with no guard. When an external API (e.g. TerraformersMC's boat API) already registers a boat/chest-boat type and a downstream dev also exposes that same instance in a container, the scanner registers it a second time, throwing `Attempted to register object ... twice`.

This skips any field value already present in the target registry (`registry.getKey(v).isPresent()`) before re-registering, keeping the change minimal and focused.